### PR TITLE
[Fix] fatal error on app return from background

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Authenticates the local player with in Game Center if it's possible.
     
 ```swift
 do {
-    let isAuthenticated = try await GameCenterKit.shared.authenticate()
+    GameCenterKit.shared.authenticate { isAuthenticated in
     if isAuthenticated {
         // Local player is authenticated
     } else {


### PR DESCRIPTION
In cases where the app goes to the background and returns, the previous implementation of the authenticate method could result in a fatal error. This commit addresses the issue by refactoring the method to use a completion handler, ensuring proper handling of authentication results and preventing crashes on app return from the background.